### PR TITLE
[DO NOT MERGE THIS AS IT IS] Enable to compile libfranka 0.14 on noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 
 target_include_directories(franka PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:include/libfranka>
 )
 
 target_link_libraries(franka PRIVATE
@@ -135,16 +135,15 @@ target_link_libraries(franka PUBLIC
 )
 
 ## Installation
-include(GNUInstallDirs)
-set(INSTALL_CMAKE_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/Franka)
+set(INSTALL_CMAKE_CONFIG_DIR share/franka/cmake)
 
 install(TARGETS franka libfranka-common
   EXPORT FrankaTargets
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/libfranka
+  ARCHIVE DESTINATION lib
 )
-install(DIRECTORY include/ common/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+install(DIRECTORY include/ common/include/ DESTINATION include/libfranka
   USE_SOURCE_PERMISSIONS
 )
 
@@ -171,6 +170,9 @@ install(EXPORT FrankaTargets
   NAMESPACE Franka::
   DESTINATION ${INSTALL_CMAKE_CONFIG_DIR}
 )
+
+# Install catkin package.xml
+install(FILES package.xml DESTINATION share/libfranka)
 
 ## Subprojects
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -63,8 +63,7 @@ target_link_libraries(joint_impedance_control Threads::Threads pinocchio::pinocc
 target_link_libraries(motion_with_control Poco::Foundation)
 target_link_libraries(motion_with_control_external_control_loop Poco::Foundation)
 
-include(GNUInstallDirs)
 install(TARGETS ${EXAMPLES}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/libfranka
 )

--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,10 @@
 
   <build_depend>eigen</build_depend>
   <build_depend>libpoco-dev</build_depend>
+  <build_depend>pinocchio</build_depend>
 
   <exec_depend>libpoco-dev</exec_depend>
+  <exec_depend>pinocchio</exec_depend>
 
   <doc_depend>doxygen</doc_depend>
   <doc_depend>graphviz</doc_depend>


### PR DESCRIPTION
I created this PR because someone may be interested in this branch.
I made it possible to compile https://github.com/frankaemika/libfranka-release/tree/release/humble/libfranka/0.14.2-1 on ROS noetic with the following changes:
- https://github.com/frankaemika/libfranka-release/commit/1dffd4fad22ae455dab1d16ea14a5f4f672f2418
- https://github.com/frankaemika/libfranka-release/commit/d10e61b015ce171c9e4bab213ff002ebea2a1c62
- Add dependency to `pinocchio` to make it installable via `rosdep install`